### PR TITLE
Fix the issue while accessing credentials

### DIFF
--- a/lib/unified_settings/handlers/credentials.rb
+++ b/lib/unified_settings/handlers/credentials.rb
@@ -37,6 +37,21 @@ module UnifiedSettings
 
         Rails.application.credentials.dig(*key_arr.map(&:upcase))
       end
+
+      protected
+
+      def nested_key_exists?(hash, keys)
+        return false if hash.nil?
+
+        current_level = hash.config
+        keys.each do |key|
+          return false if current_level.nil?
+          return true if current_level.key?(key)
+
+          current_level = current_level[key]
+        end
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
There's a `key?` method in https://github.com/rails/rails/blob/v7.1.1/activesupport/lib/active_support/encrypted_file.rb#L58-L60

And now `<ActiveSupport::EncryptedConfiguration>` breaks as `key?` accepts no params.

So now we access the config with `hash.config` which returns a `hash` object instead of `ActiveSupport::EncryptedConfiguration` 

```ruby
    def key?
      read_env_key || read_key_file
    end
```


